### PR TITLE
Add filter hook to allow the cp related posts content to be overridden.

### DIFF
--- a/cp-related-posts.php
+++ b/cp-related-posts.php
@@ -860,7 +860,7 @@ function _cprp_content( $the_content, $mode = '' ){
         $str .= '</ul></div><div style="clear:both;"></div>';
     }        
     
-    return $str;
+    return apply_filters( 'cprp_content', $str, $related_posts );
 } // End _cprp_content
 
 function cprp_content( $the_content ){


### PR DESCRIPTION
It would be great if we could override the markup of the related posts.  I've added a filter hook to the plugin, which then allows me to override the markup in my theme.

Tested and working with the following code in my theme:

``` php
/** 
 *  Override the markup for the related posts.
 **/
function aamhc_related_posts_content($str, $related_posts) {
  if( count( $related_posts ) ){

        $h = min( count( $related_posts ), cprp_get_settings( 'number_of_posts' ) ); 
        $str = '<div class="row row--you-may-also-like">
                  <div class="columns small-12">
                    <h4 class="page-also-like">You may also like</h4>
                  </div>
                </div>';

        for( $i = 0; $i < $h; $i++ ) {

          $thumb = '';
          $link = get_permalink( $related_posts[ $i ]->ID );

          $str .= '<article class="you-may-like column small-12 medium-4 home-grid">' .
                    '<div class="page-grid-body eq-height-div">' .
                      '<a href="' . $link . '">' . get_the_post_thumbnail( $related_posts[ $i ]->ID, 'recent-feature' ) . '</a>' .
                      '<a href="' . get_the_permalink($related_posts[ $i ]->ID) . '"><h2>' . get_the_title($related_posts[ $i ]->ID) . '</h2></a>' .
                      '<p>' . wp_trim_words( strip_shortcodes( $related_posts[ $i ]->post_content ) ) . '... <span class="excerpt-read-more"><a href="' . get_the_permalink($related_posts[ $i ]->ID) . '">&raquo; Read More</a></span></p>' .
                    '</div>' .
                '</article>';
        }
  }
  return $str;
}
add_filter('cprp_content', 'aamhc_related_posts_content', 10, 2);
```
